### PR TITLE
Fixes to resampling rev output and scaling streamlining

### DIFF
--- a/tech_opportunity_analysis/format_rev_output.py
+++ b/tech_opportunity_analysis/format_rev_output.py
@@ -124,21 +124,18 @@ class rev_postprocessing:
         county_gen.iloc[:, 0] = np.roll(county_gen, timezone)
 
         def get_county_gen_month(county_gen, county_fips):
-            """Sums county generation by month (in MWh); calculates kW peak"""
+            """Sums county generation by month (in MWh); calculates MW peak"""
 
             county_gen_month = \
                 county_gen.groupby(by=county_gen.index.month)[h5_index].agg(
                     ['sum', 'max']
-                    )
+                    )/1000
 
-            # Convert from kWh to MWh
-            county_gen_month['sum'] = county_gen_month['sum']/1000
-
-            county_gen_month.rename(columns={'sum': 'MWh', 'max': 'kW_peak'},
+            county_gen_month.rename(columns={'sum': 'MWh', 'max': 'MW_peak'},
                                     inplace=True)
 
             county_gen_month['yield'] = county_gen_month.MWh.divide(
-                county_gen_month.kW_peak
+                county_gen_month.MW_peak
                 )
 
             return county_gen_month
@@ -148,7 +145,7 @@ class rev_postprocessing:
         # resource_annual = self.resource.sum()*1000**2
         county_gen_month = get_county_gen_month(county_gen, county_fips)
 
-        month_yield = county_gen_month.xs(month)['yield']
+        month_yield = county_gen_month.xs(month)['yield']  # MWh/MWpeak
 
         month_gen = county_gen_month.xs(month)['MWh']
 

--- a/tech_opportunity_analysis/format_rev_output.py
+++ b/tech_opportunity_analysis/format_rev_output.py
@@ -8,13 +8,11 @@ import os
 class rev_postprocessing:
 
     def __init__(self, rev_output_filepath, solar_tech):
-
         """
         Solar_tech is 'ptc_tes', 'ptc_notes', 'dsg_lf', 'pv', or 'swh'.
         """
 
         self.data_dir = './calculation_data/'
-
         gid_fips_file = 'county_center.csv'
 
         self.solar_tech = solar_tech
@@ -80,28 +78,25 @@ class rev_postprocessing:
             """
 
             if dataset == 'resource':
-
                 dataset_name = 'gh'
 
             else:
-
                 dataset_name = generation_groups[self.solar_tech][dataset][0]
 
             resampled_df = pd.DataFrame(
                 h5py_file[dataset_name][:, :], index=time_index
                 )
 
-            resampled_df = resampled_df.resample('H').sum()
+            # reV output in 30-min intervals
+            resampled_df = resampled_df.resample('H').sum() * 0.5
 
             # PTC and thermal generation in MWt; SWH in kW
             # Solar resources for both in kW/m2.
             if (dataset_name == 'q_dot_to_heat_sink'):
-
                 resampled_df = resampled_df*1000
 
             # PV generation in W
             if (dataset == 'power') & (self.solar_tech in ['pv_ac', 'pv_dc']):
-
                 resampled_df = resampled_df/1000
 
             return resampled_df
@@ -129,17 +124,20 @@ class rev_postprocessing:
         county_gen.iloc[:, 0] = np.roll(county_gen, timezone)
 
         def get_county_gen_month(county_gen, county_fips):
+            """Sums county generation by month (in MWh); calculates kW peak"""
 
-            # calc January yield (kWh/kWp)
             county_gen_month = \
                 county_gen.groupby(by=county_gen.index.month)[h5_index].agg(
                     ['sum', 'max']
                     )
 
-            county_gen_month.rename(columns={'sum': 'kWh', 'max': 'kW_peak'},
+            # Convert from kWh to MWh
+            county_gen_month['sum'] = county_gen_month['sum']/1000
+
+            county_gen_month.rename(columns={'sum': 'MWh', 'max': 'kW_peak'},
                                     inplace=True)
 
-            county_gen_month['yield'] = county_gen_month.kWh.divide(
+            county_gen_month['yield'] = county_gen_month.MWh.divide(
                 county_gen_month.kW_peak
                 )
 
@@ -152,8 +150,7 @@ class rev_postprocessing:
 
         month_yield = county_gen_month.xs(month)['yield']
 
-        # Convert from kWh to MWh
-        month_gen = county_gen_month.xs(month)['kWh']/1000
+        month_gen = county_gen_month.xs(month)['MWh']
 
         area_avail = self.area_avail.xs(county_fips)[
             'county_included_area_km2'
@@ -162,16 +159,18 @@ class rev_postprocessing:
         # Convert footprint from m2/MW to km2/MW
         footprint = self.generation_group['footprint']/1000**2
 
-        # county_peak is in MWh (or MW).
+        # county_peak is in MWh (or MW); county_gen in kW
         # (MWh/MW)/(km2/MW)*km2
-        # rounds up
-        if (np.ceil(area_avail/footprint)*month_gen) <= county_peak:
-            scaled_gen = county_gen*np.ceil(area_avail/footprint)/1000
+        # rounds down
+        if (np.floor(area_avail/footprint)*month_gen) <= county_peak:
+            scaled_gen = county_gen*np.floor(area_avail/footprint)/1000
             used_area_abs = area_avail
 
         else:
-            # round up for number of generating units
-            scaled_gen = np.ceil(county_peak/month_yield)
+            # scaled_gen is equivalent to the number of ~1MW generating
+            # units required to meet demand.
+            # round down for number of generating units
+            scaled_gen = np.floor(county_peak/month_yield)
             used_area_abs = scaled_gen*footprint
             scaled_gen = scaled_gen * county_gen/1000
 


### PR DESCRIPTION
Fixed resampling of reV output from 30-minute intervals to hourly intervals. Previously, the correction factor of 0.5 was
missing. The unit conversions related to generation scaling were also streamlined to avoid confusion (i.e., the conversion
from kWH for month_gen and month_yield now occur within the get_county_gen_month method).
The rounding of scaled generation was also changed, from rounding up to rounding down to the nearest 1-MW unit. It was
observed that the previous approach resulted in small exceedances of available land area for some counties.